### PR TITLE
Fix misleading indentation in Image.cc

### DIFF
--- a/Source/Image.cc
+++ b/Source/Image.cc
@@ -199,7 +199,8 @@ bool Image::Fill (const Color& color)
 	// Loop data and fill contents
 	uint32 argb = color.GetARGB();
 	for (uint32 i = 0; i < mLength; ++i)
-		mData[i] = argb; return true;
+		mData[i] = argb;
+	return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The return statement was wrapped in a confusing way.
